### PR TITLE
Send ERC20 funds to Bank contract instead of DAO

### DIFF
--- a/contracts/adapters/Onboarding.sol
+++ b/contracts/adapters/Onboarding.sol
@@ -331,7 +331,7 @@ contract OnboardingContract is
                 bank.addToBalance(GUILD, token, proposal.amount);
 
                 IERC20 erc20 = IERC20(token);
-                erc20.safeTransfer(address(dao), proposal.amount);
+                erc20.safeTransfer(address(bank), proposal.amount);
             }
 
             uint256 totalShares =


### PR DESCRIPTION
Fix: moving the ERC20 funds to the Bank account instead of moving it to the DAO registry account.