### PR TITLE
send erc20 funds to Bank contract instead of DAO

### DIFF
--- a/contracts/adapters/Tribute.sol
+++ b/contracts/adapters/Tribute.sol
@@ -249,7 +249,7 @@ contract TributeContract is ITribute, DaoConstants, MemberGuard, AdapterGuard {
             }
             bank.addToBalance(GUILD, token, proposal.tributeAmount);
             IERC20 erc20 = IERC20(token);
-            erc20.safeTransfer(address(dao), proposal.tributeAmount);
+            erc20.safeTransfer(address(bank), proposal.tributeAmount);
         } else if (
             voteResult == IVoting.VotingState.NOT_PASS ||
             voteResult == IVoting.VotingState.TIE


### PR DESCRIPTION
Fix: moving the ERC20 funds to the Bank account instead of moving it to the DAO registry account.

This same fix should be made to the Tribute adapter as it was done in #198 for the Onboarding adapter.