### PR TITLE
Updated rageKick to use current balances in 1 tx

### DIFF
--- a/contracts/adapters/interfaces/IGuildKick.sol
+++ b/contracts/adapters/interfaces/IGuildKick.sol
@@ -38,5 +38,5 @@ interface IGuildKick {
 
     function processProposal(DaoRegistry dao, bytes32 proposalId) external;
 
-    function rageKick(DaoRegistry dao, uint256 toIndex) external;
+    function rageKick(DaoRegistry dao) external;
 }

--- a/test/adapters/guildkick.test.js
+++ b/test/adapters/guildkick.test.js
@@ -1002,8 +1002,7 @@ contract("MolochV3 - GuildKick Adapter", async (accounts) => {
     assert.equal(memberLoot.toString(), "10000000000000000");
 
     // Process guild kick to remove the voting power of the kicked member
-    let toIndex = 10;
-    await guildkickContract.rageKick(dao.address, toIndex, {
+    await guildkickContract.rageKick(dao.address, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -1064,8 +1063,7 @@ contract("MolochV3 - GuildKick Adapter", async (accounts) => {
     });
 
     // Process guild kick to remove the voting power of the kicked member
-    let toIndex = 1;
-    await guildkickContract.rageKick(dao.address, toIndex, {
+    await guildkickContract.rageKick(dao.address, {
       from: member,
       gasPrice: toBN("0"),
     });


### PR DESCRIPTION
Updated GuildKick Adapter to use current guild balances during the `rageKick` process to prevent any credit issues during the distribution phase.

In addition to that, the `rageKick` was also updated to iterate over all tokens of the bank. At this moment we haven't set a maximum limit for the number of available tokens, so we will face issues with the block size limit. However, the maximum limit of available tokens will be addressed in another ticket. 