### PR TITLE
use websocket connection to infura

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -48,7 +48,7 @@ module.exports = {
         let infuraKey = process.env.INFURA_KEY;
         let HDWalletProvider = require("@truffle/hdwallet-provider");
         let mnemonic = process.env.TRUFFLE_MNEMONIC;
-        let infuraUrl = "https://rinkeby.infura.io/v3/" + infuraKey;
+        let infuraUrl = "wss://rinkeby.infura.io/ws/v3/" + infuraKey;
         return new HDWalletProvider(mnemonic, infuraUrl);
       },
       network_id: 4,


### PR DESCRIPTION
Deploying the contract set to rinkeby with `truffle deploy --network rinkeby` frequently errors out with `Error: PollingBlockTracker - encountered an error while attempting to update latest block`. This change to use the websocket connection to Infura has helped.