### PR TITLE
Added basic events for NFT extension

### DIFF
--- a/contracts/extensions/nft/NFT.sol
+++ b/contracts/extensions/nft/NFT.sol
@@ -50,6 +50,11 @@ contract NFTExtension is
     DaoRegistry public dao;
     address private _creator;
 
+    event CollectedNFT(address nftAddr, uint256 nftTokenId);
+    event RegisteredNFT(address nftAddr);
+    event ReturnedNFT(address nftAddr, uint256 nftTokenId, address newOwner);
+    event TransferredNFT(address nftAddr, uint256 nftTokenId);
+
     enum AclFlag {TRANSFER_NFT, RETURN_NFT, REGISTER_NFT, COLLECT_NFT}
 
     // All the NFTs and Token ids that belong to the GUILD
@@ -127,6 +132,8 @@ contract NFTExtension is
         _nftCollection[GUILD][nftAddr].add(nftTokenId);
         // Keep track of the collected assets
         _collectedNFTs.add(nftAddr);
+
+        emit CollectedNFT(nftAddr, nftTokenId);
     }
 
     /**
@@ -152,10 +159,12 @@ contract NFTExtension is
         _nftCollection[GUILD][nftAddr].add(nftTokenId);
         // Keep track of the collected assets
         _collectedNFTs.add(nftAddr);
+
+        emit TransferredNFT(nftAddr, nftTokenId);
     }
 
     /**
-     * @notice Ttransfers the NFT token from the extension address to the new owner.
+     * @notice Transfers the NFT token from the extension address to the new owner.
      * @notice It also updates the internal state to keep track of the all the NFTs collected by the extension.
      * @notice The caller must have the ACL Flag: RETURN_NFT
      * @dev Reverts if the NFT is not support/allowed, or is not in ERC721 standard.
@@ -179,6 +188,8 @@ contract NFTExtension is
         if (_nftCollection[GUILD][nftAddr].length() == 0) {
             _collectedNFTs.remove(nftAddr);
         }
+
+        emit ReturnedNFT(nftAddr, nftTokenId, newOwner);
     }
 
     /**
@@ -199,6 +210,8 @@ contract NFTExtension is
         if (!availableNFTs[nftAddr]) {
             availableNFTs[nftAddr] = true;
         }
+
+        emit RegisteredNFT(nftAddr);
     }
 
     /**

--- a/docs/extensions/NFT.md
+++ b/docs/extensions/NFT.md
@@ -161,3 +161,10 @@ function onERC721Received(
     bytes calldata data
 ) external override returns (bytes4)
 ```
+
+## Events
+
+- `CollectedNFT`: when a NFT is collected/stored into the NFT collection.
+- `RegisteredNFT`: when a new NFT address is registered into the NFT collection, so it can be collected.
+- `ReturnedNFT`: when a NFT is transferred from the extension to another owner.
+- `TransferredNFT`: when a NFT is transferred from the escrow adapter to the NFT collection in the extension.


### PR DESCRIPTION
Creating events for the 4 main operations supported by the NFT Extension.

The NFT extension will emit the following events:
- `CollectedNFT`: when a NFT is collected/stored into the NFT collection.
- `RegisteredNFT`: when a new NFT address is registered into the NFT collection, so it can be collected.
- `ReturnedNFT`: when a NFT is transferred from the extension to another owner.
- `TransferredNFT`: when a NFT is transferred from the escrow adapter to the NFT collection in the extension.