### PR TITLE
allow custom DAO name for deployment

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -65,6 +65,7 @@ async function deployRinkebyDao(deployer, network) {
     deployTestTokens: true,
     finalize: false,
     couponCreatorAddress: process.env.COUPON_CREATOR_ADDR,
+    daoName: process.env.DAO_NAME,
   });
   return dao;
 }
@@ -81,6 +82,8 @@ async function deployGanacheDao(deployer, network) {
     chainId: getNetworkDetails(network).chainId,
     deployTestTokens: true,
     finalize: false,
+    couponCreatorAddress: process.env.COUPON_CREATOR_ADDR,
+    daoName: process.env.DAO_NAME,
   });
   return dao;
 }

--- a/utils/DaoFactory.js
+++ b/utils/DaoFactory.js
@@ -236,6 +236,7 @@ const deployDao = async (deployer, options) => {
   const couponCreatorAddress =
     options.couponCreatorAddress ||
     "0x7D8cad0bbD68deb352C33e80fccd4D8e88b4aBb8";
+  const daoName = options.daoName || "test-dao";
 
   let daoRegistry;
   let bankFactory;
@@ -281,7 +282,12 @@ const deployDao = async (deployer, options) => {
     nftFactory = await NFTCollectionFactory.new(nftExt.address);
   }
 
-  const { dao, daoFactory } = await cloneDao(deployer, daoRegistry, owner);
+  const { dao, daoFactory } = await cloneDao(
+    deployer,
+    daoRegistry,
+    owner,
+    daoName
+  );
 
   await bankFactory.createBank(maxExternalTokens);
   let pastEvent;


### PR DESCRIPTION
Adds option in deployment configs for DAO creator to set custom name (otherwise everything is named `test-dao`).

Also adds `couponCreatorAddress` option to Ganache deployment.