### PR TITLE
add member to DAO for CouponOnboarding

### DIFF
--- a/contracts/adapters/CouponOnboarding.sol
+++ b/contracts/adapters/CouponOnboarding.sol
@@ -119,6 +119,12 @@ contract CouponOnboardingContract is DaoConstants, AdapterGuard, Signatures {
             address(dao.getAddressConfiguration(TokenAddrToMint));
 
         BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
-        bank.addToBalance(authorizedMember, tokenAddrToMint, amount);
+        // Overflow risk may cause this to fail
+        try bank.addToBalance(authorizedMember, tokenAddrToMint, amount) {
+            // address needs to be added to the members mappings
+            dao.potentialNewMember(authorizedMember);
+        } catch {
+            // do nothing
+        }
     }
 }


### PR DESCRIPTION
Fixes bug I discovered when working on an interface to implement the Coupon Onboarding. The address receives `SHARES` but it does not actually get added to the appropriate DAO registry mappings as a member. As a result, the address is not detected as an actual "member" in some checks used in the frontend.

