### PR TITLE
adds back ability to name DAO with configs

### DIFF
--- a/utils/DeploymentUtil.js
+++ b/utils/DeploymentUtil.js
@@ -56,7 +56,7 @@ const deployDao = async (options) => {
   const { dao, daoFactory } = await cloneDao({
     ...options,
     identityDao,
-    name: "test-dao",
+    name: options.daoName || "test-dao",
   });
 
   await bankFactory.createBank(options.maxExternalTokens);


### PR DESCRIPTION
Fixes recent regression where `options.daoName` was not being applied.